### PR TITLE
Fix incomplete video streams

### DIFF
--- a/web/routes/capture_routes.py
+++ b/web/routes/capture_routes.py
@@ -206,7 +206,7 @@ def create_capture_routes(app, capture_service, sync_service, settings_repo):
         """Proxy video requests to the processing server."""
         try:
             url = f"{sync_service.base_url}/videos/{filename}"
-            resp = requests.get(url, stream=True, timeout=10)
+            resp = requests.get(url, stream=True)  # No timeout to avoid truncated streams
 
             if resp.status_code == 200:
                 return Response(
@@ -223,7 +223,7 @@ def create_capture_routes(app, capture_service, sync_service, settings_repo):
         """Proxy thumbnail requests to the processing server."""
         try:
             url = f"{sync_service.base_url}/thumbnails/{filename}"
-            resp = requests.get(url, stream=True, timeout=10)
+            resp = requests.get(url, stream=True)  # No timeout to avoid truncated streams
 
             if resp.status_code == 200:
                 return Response(


### PR DESCRIPTION
## Summary
- disable short request timeouts when proxying videos and thumbnails

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68475feeae0083248a60e38aec7a89ef