### PR TITLE
UI: replace text indicators with circles

### DIFF
--- a/services/capture_service.py
+++ b/services/capture_service.py
@@ -39,6 +39,8 @@ class CaptureService:
         self.is_running = False
         self.last_motion_time = 0
         self.segment_start_time = 0
+        # Latest motion state for UI indicators
+        self.latest_motion = False
         
         # Pre-motion buffer (15 seconds worth of frames)
         buffer_size = capture_config.fps * 15  # 15 seconds of frames
@@ -100,6 +102,7 @@ class CaptureService:
             
             # Detect motion
             has_motion = self.motion_detector.detect_motion(frame)
+            self.latest_motion = has_motion
             
             # Handle motion detection
             if has_motion:

--- a/web/routes/capture_routes.py
+++ b/web/routes/capture_routes.py
@@ -26,6 +26,7 @@ def create_capture_routes(app, capture_service, sync_service, settings_repo):
         return jsonify({
             'pi': {
                 'is_capturing': status.is_capturing,
+                'has_motion': getattr(capture_service, 'latest_motion', False),
                 'queue_size': status.queue_size,
                 'last_motion': status.last_motion_time.isoformat() if status.last_motion_time else None,
                 'total_videos': 0,  # TODO: Add to capture service
@@ -187,11 +188,7 @@ def create_capture_routes(app, capture_service, sync_service, settings_repo):
                     
                     try:
                         has_motion = capture_service.motion_detector.detect_motion(frame.copy())
-                        color = (0, 255, 0) if has_motion else (0, 0, 255)
-                        cv2.putText(frame, f"Motion: {has_motion}", (10, 30),
-                                   cv2.FONT_HERSHEY_SIMPLEX, 1, color, 2)
-                        cv2.putText(frame, f"Recording: {capture_service.is_capturing}", (10, 70),
-                                   cv2.FONT_HERSHEY_SIMPLEX, 1, color, 2)
+                        capture_service.latest_motion = has_motion
                         
                         if capture_service.motion_detector.motion_region:
                             region = capture_service.motion_detector.motion_region

--- a/web/static/js/unified.js
+++ b/web/static/js/unified.js
@@ -64,6 +64,12 @@ function updatePiStatus(data) {
         captureText.textContent = 'MONITORING - Waiting for motion';
         recordingIndicator.className = 'recording-badge';
     }
+
+    if (pi.has_motion) {
+        motionIndicator.className = 'motion-badge active';
+    } else {
+        motionIndicator.className = 'motion-badge';
+    }
     
     // Update mini stats
     document.getElementById('pi-total-videos').textContent = pi.total_videos || '-';

--- a/web/templates/unified_dashboard.html
+++ b/web/templates/unified_dashboard.html
@@ -86,8 +86,8 @@
         <div class="live-feed-container">
             <img src="/live_feed" alt="Live Camera" id="live-feed" onerror="handleImageError(this)">
             <div class="feed-overlay">
-                <span id="motion-indicator" class="motion-badge">●</span>
-                <span id="recording-indicator" class="recording-badge">●</span>
+                <span id="motion-indicator" class="motion-badge" title="Motion detected">●</span>
+                <span id="recording-indicator" class="recording-badge" title="Recording active">●</span>
             </div>
         </div>
         <p class="feed-info">Live camera with motion detection overlay</p>


### PR DESCRIPTION
## Summary
- store latest motion state in CaptureService
- expose `has_motion` via `/api/status`
- update live feed overlay to stop drawing motion text
- activate motion circle in dashboard
- add tooltip titles for motion and recording indicators

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684accadf9488324bb9fefa1a75db6a3