### PR TITLE
Remove outdated STREAM_URL default

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -33,8 +33,8 @@ NO_DETECTION_RETENTION_DAYS=7
 # =============================================================================
 # PI CAPTURE SETTINGS
 # =============================================================================
-STREAM_URL=rtsp://192.168.1.136:8554/birdcam
-# RTSP stream URL from your camera
+# STREAM_URL=
+# Optional RTSP stream URL from your camera (leave unset for local capture)
 
 # Motion detection settings
 MOTION_THRESHOLD=5000

--- a/config/settings.py
+++ b/config/settings.py
@@ -129,7 +129,7 @@ def load_capture_config() -> AppConfig:
     return AppConfig(
         database=DatabaseConfig(path=base_path / "capture.db"),
         capture=CaptureConfig(
-            stream_url=os.getenv('STREAM_URL', 'rtsp://192.168.1.136:8554/birdcam'),
+            stream_url=os.getenv('STREAM_URL', ''),  # Optional RTSP fallback
             segment_duration=get_int_env('SEGMENT_DURATION', 300),
             fps=get_int_env('FPS', 10),
             resolution=(get_int_env('RESOLUTION_WIDTH', 640), get_int_env('RESOLUTION_HEIGHT', 480)),


### PR DESCRIPTION
## Summary
- remove the obsolete default STREAM_URL from `.env_sample`
- default to empty STREAM_URL in `config/settings.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b5038cec08324a11d3eac632b0c1c