### PR TITLE
Remove STREAM_URL references

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -33,8 +33,6 @@ NO_DETECTION_RETENTION_DAYS=7
 # =============================================================================
 # PI CAPTURE SETTINGS
 # =============================================================================
-# STREAM_URL=
-# Optional RTSP stream URL from your camera (leave unset for local capture)
 # CAMERA_TYPE=opencv
 # Set to "picamera2" for Raspberry Pi CSI cameras
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -131,7 +131,7 @@ def load_capture_config() -> AppConfig:
         database=DatabaseConfig(path=base_path / "capture.db"),
         capture=CaptureConfig(
             camera_type=os.getenv('CAMERA_TYPE', 'opencv'),
-            stream_url=os.getenv('STREAM_URL', ''),  # Optional RTSP fallback
+            stream_url='',  # RTSP environment variable removed
             segment_duration=get_int_env('SEGMENT_DURATION', 300),
             fps=get_int_env('FPS', 10),
             resolution=(get_int_env('RESOLUTION_WIDTH', 640), get_int_env('RESOLUTION_HEIGHT', 480)),

--- a/zarchive/client/pi_capture.py
+++ b/zarchive/client/pi_capture.py
@@ -493,10 +493,9 @@ capture_system = None
 def initialize_system():
     global capture_system
     # Configuration
-    STREAM_URL = "rtsp://192.168.1.136:8554/birdcam"
     PROCESSING_SERVER = "192.168.1.136"  # IP of your powerful computer
-    
-    capture_system = PiCaptureSystem(STREAM_URL, processing_server=PROCESSING_SERVER)
+
+    capture_system = PiCaptureSystem("", processing_server=PROCESSING_SERVER)
     
     # Start capture
     capture_thread = threading.Thread(target=capture_system.continuous_capture, daemon=True)


### PR DESCRIPTION
## Summary
- purge deprecated `STREAM_URL` variable from sample environment file
- stop loading `STREAM_URL` in settings
- clean up archived client code

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b56ef7c78832499f5d1ec19ca9938