### PR TITLE
Fix per-camera motion region

### DIFF
--- a/pi_capture/main.py
+++ b/pi_capture/main.py
@@ -135,7 +135,7 @@ def cleanup_old_files(storage_path: Path, days_to_keep: int):
                 file_path.unlink()
                 print(f"🗑️ Cleaned up: {file_path.name}")
 
-def create_unified_app(capture_services, sync_service, settings_repo, config):
+def create_unified_app(capture_services, sync_service, settings_repos, config):
     """Create Flask app with unified dashboard"""
     from flask import Flask
     from flask_cors import CORS
@@ -148,7 +148,7 @@ def create_unified_app(capture_services, sync_service, settings_repo, config):
     
     # Import and register routes with settings repo
     from web.routes.capture_routes import create_capture_routes
-    create_capture_routes(app, capture_services, sync_service, settings_repo)
+    create_capture_routes(app, capture_services, sync_service, settings_repos)
     
     return app
 
@@ -163,17 +163,16 @@ def main():
 
         capture_services = {}
         sync_service = None
-        settings_repo = None
+        settings_repos = {}
 
         for cfg in configs:
             print(f"📁 Storage for camera {cfg.capture.camera_id}: {cfg.processing.storage_path}")
 
             cs, sync, settings = setup_services(cfg)
             capture_services[cfg.capture.camera_id] = cs
+            settings_repos[cfg.capture.camera_id] = settings
             if sync_service is None:
                 sync_service = sync
-            if settings_repo is None:
-                settings_repo = settings
 
             setup_scheduler(cs, cfg)
 
@@ -186,7 +185,7 @@ def main():
 
         # Start web interface with unified dashboard using first config
         print("🌐 Starting unified dashboard...")
-        app = create_unified_app(capture_services, sync_service, settings_repo, configs[0])
+        app = create_unified_app(capture_services, sync_service, settings_repos, configs[0])
         
         print(f"✅ Unified Dashboard ready!")
         print(f"🌐 Access at: http://0.0.0.0:{configs[0].web.capture_port}")

--- a/web/app.py
+++ b/web/app.py
@@ -16,7 +16,7 @@ def create_capture_app(capture_services, sync_service, config):
     
     # Import and register routes
     from web.routes.capture_routes import create_capture_routes
-    create_capture_routes(app, capture_services, sync_service)
+    create_capture_routes(app, capture_services, sync_service, {})
     
     return app
 

--- a/web/static/js/unified.js
+++ b/web/static/js/unified.js
@@ -374,7 +374,7 @@ function setDefaultRegion() {
 
 async function loadCurrentSettings() {
     try {
-        const data = await apiCall('/api/motion-settings');
+        const data = await apiCall(`/api/motion-settings?camera_id=${currentCameraId}`);
         
         if (data.region) {
             currentRegion = data.region;
@@ -447,7 +447,7 @@ async function saveSettings() {
     };
     
     try {
-        const data = await apiCall('/api/motion-settings', {
+        const data = await apiCall(`/api/motion-settings?camera_id=${currentCameraId}`, {
             method: 'POST',
             body: JSON.stringify(settings)
         });
@@ -529,7 +529,7 @@ function closeVideoModal() {
 
 async function updateDebugInfo() {
     try {
-        const data = await apiCall('/api/motion-debug');
+        const data = await apiCall(`/api/motion-debug?camera_id=${currentCameraId}`);
         const debugContent = document.getElementById('debug-content');
         
         if (data.error) {


### PR DESCRIPTION
## Summary
- allow per-camera motion regions by mapping settings repositories
- pass camera ID when saving/loading regions on unified dashboard

## Testing
- `pytest -q`
- `python -m py_compile pi_capture/main.py web/routes/capture_routes.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853a369f7348324abd76744ec39cdc2