### PR TITLE
Fix picamera2 color order

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,9 @@ The system will automatically try each camera. Check logs for which camera is be
 sudo usermod -a -G video $USER
 # Log out and back in
 ```
+
+### Blue or Distorted Colors
+When using `CAMERA_TYPE=picamera2`, the camera may deliver frames in
+RGB order. Birdcam now converts these frames to BGR before processing,
+so colors in the live feed should look normal. If you still see a blue
+hue, ensure you have updated to the latest version.

--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -55,7 +55,7 @@ class CameraManager:
             try:
                 self.picam2 = Picamera2(camera_num=self.config.camera_id)
                 video_config = self.picam2.create_video_configuration(
-                    main={"size": self.config.resolution, "format": "BGR888"},
+                    main={"size": self.config.resolution, "format": "RGB888"},
                     controls={"FrameRate": self.config.fps},
                 )
                 self.picam2.configure(video_config)
@@ -91,6 +91,9 @@ class CameraManager:
         if self.camera_type == "picamera2" and self.picam2:
             try:
                 frame = self.picam2.capture_array()
+                # Picamera2 returns RGB even when BGR is requested.
+                # Convert to BGR so OpenCV processing works correctly.
+                frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
                 return True, frame
             except Exception:
                 return False, None


### PR DESCRIPTION
## Summary
- request RGB frames from picamera2 and convert to BGR when capturing
- document color fix for picamera2 in README

## Testing
- `python -m py_compile services/camera_manager.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685428d263fc83248d504888e0f787e2