### PR TITLE
Fix picamera2 color

### DIFF
--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -55,7 +55,7 @@ class CameraManager:
             try:
                 self.picam2 = Picamera2(camera_num=self.config.camera_id)
                 video_config = self.picam2.create_video_configuration(
-                    main={"size": self.config.resolution, "format": "RGB888"},
+                    main={"size": self.config.resolution},
                     controls={"FrameRate": self.config.fps},
                 )
                 self.picam2.configure(video_config)


### PR DESCRIPTION
## Summary
- match working demo by using default color format for picamera2 video stream

## Testing
- `python -m py_compile services/camera_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68542ea1ac1c83249f0e42859a737388