### PR TITLE
Show server addresses on unified dashboard

### DIFF
--- a/web/routes/capture_routes.py
+++ b/web/routes/capture_routes.py
@@ -28,9 +28,22 @@ def create_capture_routes(app, capture_services, sync_service, settings_repos):
     
     @app.route('/')
     def dashboard():
-        # Pass processing server URL to template
+        """Unified dashboard with server addresses injected"""
         processing_server_url = f"http://{sync_service.server_host}:{sync_service.server_port}"
-        return render_template('unified_dashboard.html', processing_server_url=processing_server_url)
+
+        # Derive capture host/port from the current request
+        host_parts = request.host.split(":")
+        capture_host = host_parts[0]
+        capture_port = host_parts[1] if len(host_parts) > 1 else ("443" if request.scheme == "https" else "80")
+
+        return render_template(
+            'unified_dashboard.html',
+            processing_server_url=processing_server_url,
+            processing_host=sync_service.server_host,
+            processing_port=sync_service.server_port,
+            capture_host=capture_host,
+            capture_port=capture_port
+        )
     
     @app.route('/api/status')
     def api_status():

--- a/web/static/css/unified.css
+++ b/web/static/css/unified.css
@@ -21,6 +21,12 @@
     font-size: 1.1em;
 }
 
+.status-address {
+    margin-top: 5px;
+    font-size: 0.85em;
+    color: #7f8c8d;
+}
+
 .status-grid-mini {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/web/templates/unified_dashboard.html
+++ b/web/templates/unified_dashboard.html
@@ -19,6 +19,9 @@
                 <span id="capture-status" class="status-indicator online"></span>
                 <span id="capture-text">Loading...</span>
             </div>
+            <div class="status-address" id="pi-address">
+                {{ capture_host }}:{{ capture_port }}
+            </div>
             <div class="status-grid-mini">
                 <div class="mini-stat">
                     <span class="mini-number" id="pi-total-videos">-</span>
@@ -42,6 +45,9 @@
             <div class="status-item">
                 <span id="server-status" class="status-indicator offline"></span>
                 <span id="server-text">Checking...</span>
+            </div>
+            <div class="status-address" id="server-address">
+                {{ processing_host }}:{{ processing_port }}
             </div>
             <div class="status-grid-mini">
                 <div class="mini-stat">


### PR DESCRIPTION
## Summary
- add capture and processing server addresses to unified dashboard
- expose address information from `capture_routes`
- style addresses in dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618ea8d2dc83248d55e1f589cdd08e