### PR TITLE
Add multi camera type support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ STORAGE_PATH=./bird_processing
 CAMERA_IDS=0
 # Comma-separated list of camera IDs
 
+CAMERA_TYPES=
+# Optional comma-separated list of camera types matching CAMERA_IDS
+# ("picamera2" for CSI, "opencv" for USB). Leave blank to auto-detect.
+
 CAMERA_TYPE=opencv
 # Set to "picamera2" for Raspberry Pi CSI cameras
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,17 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-### Multiple Cameras Detected
-The system will automatically try each camera. Check logs for which camera is being used.
+### Multiple Cameras
+Birdcam can run several cameras at once. List camera IDs in `CAMERA_IDS` and
+their matching types in `CAMERA_TYPES`. Leave `CAMERA_TYPES` blank to let
+Birdcam auto-detect the type.
+
+Example:
+
+```bash
+CAMERA_IDS=0,1
+CAMERA_TYPES=picamera2,opencv
+```
 
 ### Permission Errors
 ```bash

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import os
 from typing import Tuple, Optional, List, Dict
 from dotenv import load_dotenv
+from services.camera_manager import detect_available_cameras
 
 # Load .env file
 load_dotenv()
@@ -124,7 +125,7 @@ class AppConfig:
     sync: SyncConfig
     web: WebConfig
 
-def load_capture_config(camera_id: int = 0) -> AppConfig:
+def load_capture_config(camera_id: int = 0, camera_type: Optional[str] = None) -> AppConfig:
     """Load configuration for Pi capture system"""
     base_path = Path(os.getenv('STORAGE_PATH', './bird_footage'))
     camera_path = base_path / f"camera_{camera_id}"
@@ -133,7 +134,7 @@ def load_capture_config(camera_id: int = 0) -> AppConfig:
         database=DatabaseConfig(path=camera_path / "capture.db"),
         capture=CaptureConfig(
             camera_id=camera_id,
-            camera_type=os.getenv('CAMERA_TYPE', 'opencv'),
+            camera_type=camera_type or os.getenv('CAMERA_TYPE', 'opencv'),
             stream_url='',  # RTSP environment variable removed
             segment_duration=get_int_env('SEGMENT_DURATION', 300),
             fps=get_int_env('FPS', 10),
@@ -177,17 +178,36 @@ def load_capture_config(camera_id: int = 0) -> AppConfig:
     )
 
 def load_all_capture_configs() -> List[AppConfig]:
-    """Load configurations for all cameras listed in CAMERA_IDS"""
-    ids = os.getenv('CAMERA_IDS', '0')
+    """Load configurations for all cameras.
+
+    If CAMERA_IDS/CAmera_TYPES are provided they will be used. Otherwise the
+    system will auto-detect available cameras and their types.
+    """
+    ids_env = os.getenv('CAMERA_IDS', '')
+    types_env = get_list_env('CAMERA_TYPES', [])
+
+    detected = detect_available_cameras()
+
+    id_list = [s.strip() for s in ids_env.split(',') if s.strip()] if ids_env else [cam['id'] for cam in detected]
+
     configs: List[AppConfig] = []
-    for id_str in ids.split(','):
-        id_str = id_str.strip()
-        if id_str:
-            try:
-                cam_id = int(id_str)
-            except ValueError:
-                continue
-            configs.append(load_capture_config(cam_id))
+    for idx, id_str in enumerate(id_list):
+        try:
+            cam_id = int(id_str)
+        except ValueError:
+            continue
+
+        cam_type: Optional[str] = None
+        if idx < len(types_env) and types_env[idx]:
+            cam_type = types_env[idx].lower()
+        else:
+            for cam in detected:
+                if cam['id'] == id_str:
+                    cam_type = cam['type']
+                    break
+
+        configs.append(load_capture_config(cam_id, cam_type))
+
     return configs
 
 def load_processing_config() -> AppConfig:

--- a/pi_capture/main.py
+++ b/pi_capture/main.py
@@ -170,7 +170,12 @@ def main():
         settings_repos = {}
 
         for cfg in configs:
-            print(f"📁 Storage for camera {cfg.capture.camera_id}: {cfg.processing.storage_path}")
+            print(
+                f"📁 Storage for camera {cfg.capture.camera_id}: {cfg.processing.storage_path}"
+            )
+            print(
+                f"📷 Using {cfg.capture.camera_type} for camera {cfg.capture.camera_id}"
+            )
 
             cs, sync, settings = setup_services(cfg)
             capture_services[cfg.capture.camera_id] = cs

--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -39,7 +39,8 @@ def print_detected_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
     else:
         print(f"✅ Found {len(cams)} camera(s):")
         for cam in cams:
-            print(f" - ID {cam['id']} ({cam['type']})")
+            pretty = "CSI" if cam["type"] == "picamera2" else "OpenCV"
+            print(f" - ID {cam['id']} ({pretty})")
     return cams
 
 class CameraManager:


### PR DESCRIPTION
## Summary
- detect cameras on startup with clearer output
- allow configuration of different camera types per camera via `CAMERA_TYPES`
- show camera type when starting each capture service
- document new behaviour and env vars

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(failed: `cv2` unavailable when running detection test)*

------
https://chatgpt.com/codex/tasks/task_e_68619ba58d248324a0621653c401bbca