### PR TITLE
Fix circular import preventing startup

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import os
 from typing import Tuple, Optional, List, Dict
 from dotenv import load_dotenv
-from services.camera_manager import detect_available_cameras
 
 # Load .env file
 load_dotenv()
@@ -186,6 +185,7 @@ def load_all_capture_configs() -> List[AppConfig]:
     ids_env = os.getenv('CAMERA_IDS', '')
     types_env = get_list_env('CAMERA_TYPES', [])
 
+    from services.camera_manager import detect_available_cameras
     detected = detect_available_cameras()
 
     id_list = [s.strip() for s in ids_env.split(',') if s.strip()] if ids_env else [cam['id'] for cam in detected]

--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -1,8 +1,10 @@
 # services/camera_manager.py
 import cv2
 import numpy as np
-from typing import Optional, Tuple, List, Dict
-from config.settings import CaptureConfig
+from typing import Optional, Tuple, List, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:  # Avoid circular import at runtime
+    from config.settings import CaptureConfig
 
 try:
     from picamera2 import Picamera2
@@ -44,7 +46,7 @@ def print_detected_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
     return cams
 
 class CameraManager:
-    def __init__(self, config: CaptureConfig):
+    def __init__(self, config: 'CaptureConfig'):
         self.config = config
         self.camera_type = config.camera_type.lower()
         self.cap: Optional[cv2.VideoCapture] = None


### PR DESCRIPTION
## Summary
- break circular dependency between settings and camera manager
- lazily import camera detection in `load_all_capture_configs`
- avoid runtime import of `CaptureConfig` using `TYPE_CHECKING`

## Testing
- `python3 -m pi_capture.main` *(fails: No camera configurations found)*
- `python3 -m ai_processor.main` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6861a05fca2c832489543576d7a4e3f6