### PR TITLE
Enable picamera2 backend for USB camera detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,8 @@ CAMERA_TYPES=
 # Optional comma-separated list of camera types matching CAMERA_IDS
 # ("picamera2" for CSI, "opencv" for USB). Leave blank to auto-detect.
 
-CAMERA_TYPE=opencv
-# Set to "picamera2" for Raspberry Pi CSI cameras
+CAMERA_TYPE=picamera2
+# Default camera backend (use "picamera2" for both CSI and USB cameras)
 
 SEGMENT_DURATION=300
 # Length of each video segment in seconds

--- a/.env_sample
+++ b/.env_sample
@@ -33,8 +33,8 @@ NO_DETECTION_RETENTION_DAYS=7
 # =============================================================================
 # PI CAPTURE SETTINGS
 # =============================================================================
-# CAMERA_TYPE=opencv
-# Set to "picamera2" for Raspberry Pi CSI cameras
+# CAMERA_TYPE=picamera2
+# Default camera backend (use "picamera2" for both CSI and USB cameras)
 
 # Motion detection settings
 MOTION_THRESHOLD=5000

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ chmod +x setup_pi_camera.sh
 
 3. **Configure Environment**
    ```bash
-   echo "CAMERA_TYPE=opencv" >> .env
+   echo "CAMERA_TYPE=picamera2" >> .env
    ```
 
 ## Troubleshooting
@@ -92,7 +92,7 @@ Example:
 
 ```bash
 CAMERA_IDS=0,1
-CAMERA_TYPES=picamera2,opencv
+CAMERA_TYPES=picamera2,picamera2
 ```
 
 ### Permission Errors

--- a/config/settings.py
+++ b/config/settings.py
@@ -133,7 +133,7 @@ def load_capture_config(camera_id: int = 0, camera_type: Optional[str] = None) -
         database=DatabaseConfig(path=camera_path / "capture.db"),
         capture=CaptureConfig(
             camera_id=camera_id,
-            camera_type=camera_type or os.getenv('CAMERA_TYPE', 'opencv'),
+            camera_type=camera_type or os.getenv('CAMERA_TYPE', 'picamera2'),
             stream_url='',  # RTSP environment variable removed
             segment_duration=get_int_env('SEGMENT_DURATION', 300),
             fps=get_int_env('FPS', 10),
@@ -218,7 +218,7 @@ def load_processing_config() -> AppConfig:
         database=DatabaseConfig(path=base_path / "processing.db"),
         capture=CaptureConfig(
             camera_id=0,
-            camera_type=os.getenv('CAMERA_TYPE', 'opencv'),
+            camera_type=os.getenv('CAMERA_TYPE', 'picamera2'),
             stream_url="",  # Not used on processing server
             segment_duration=300,
             fps=10,

--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -24,6 +24,9 @@ def detect_available_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
         except Exception as e:  # pragma: no cover - hardware specific
             print(f"Picamera2 detection failed: {e}")
 
+    if cameras:
+        return cameras
+
     for i in range(max_devices):
         cap = cv2.VideoCapture(i)
         if cap.isOpened():


### PR DESCRIPTION
## Summary
- default camera type to picamera2 in configs and `.env` samples
- prefer picamera2 for camera detection
- adjust docs to use picamera2 for both cameras

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ac763c78832483da77f1decd303c