### PR TITLE
Simplify camera manager

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -133,7 +133,7 @@ def load_capture_config(camera_id: int = 0, camera_type: Optional[str] = None) -
         database=DatabaseConfig(path=camera_path / "capture.db"),
         capture=CaptureConfig(
             camera_id=camera_id,
-            camera_type=camera_type or os.getenv('CAMERA_TYPE', 'picamera2'),
+            camera_type='picamera2',
             stream_url='',  # RTSP environment variable removed
             segment_duration=get_int_env('SEGMENT_DURATION', 300),
             fps=get_int_env('FPS', 10),
@@ -218,7 +218,7 @@ def load_processing_config() -> AppConfig:
         database=DatabaseConfig(path=base_path / "processing.db"),
         capture=CaptureConfig(
             camera_id=0,
-            camera_type=os.getenv('CAMERA_TYPE', 'picamera2'),
+            camera_type='picamera2',
             stream_url="",  # Not used on processing server
             segment_duration=300,
             fps=10,

--- a/services/camera_manager.py
+++ b/services/camera_manager.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover - picamera2 may not be installed
 
 
 def detect_available_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
-    """Detect connected cameras and return their IDs and types."""
+    """Detect connected cameras and return their IDs."""
     cameras: List[Dict[str, str]] = []
 
     if Picamera2:
@@ -23,15 +23,6 @@ def detect_available_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
                 cameras.append({"id": str(idx), "type": "picamera2"})
         except Exception as e:  # pragma: no cover - hardware specific
             print(f"Picamera2 detection failed: {e}")
-
-    if cameras:
-        return cameras
-
-    for i in range(max_devices):
-        cap = cv2.VideoCapture(i)
-        if cap.isOpened():
-            cameras.append({"id": str(i), "type": "opencv"})
-            cap.release()
 
     return cameras
 
@@ -49,76 +40,47 @@ def print_detected_cameras(max_devices: int = 4) -> List[Dict[str, str]]:
     return cams
 
 class CameraManager:
+    """Simplified camera manager that always uses Picamera2."""
+
     def __init__(self, config: 'CaptureConfig'):
         self.config = config
-        self.camera_type = config.camera_type.lower()
-        self.cap: Optional[cv2.VideoCapture] = None
         self.picam2: Optional[Picamera2] = None
         self._initialize_camera()
 
-    def _initialize_camera(self):
-        if self.camera_type == "picamera2" and Picamera2:
-            try:
-                self.picam2 = Picamera2(camera_num=self.config.camera_id)
-                video_config = self.picam2.create_video_configuration(
-                    main={"size": self.config.resolution},
-                    controls={"FrameRate": self.config.fps},
-                )
-                self.picam2.configure(video_config)
-                self.picam2.start()
-                return
-            except Exception as e:
-                print(f"Picamera2 init failed: {e}, falling back to OpenCV")
-                self.picam2 = None
-                self.camera_type = "opencv"
+    def _initialize_camera(self) -> None:
+        """Initialize Picamera2 using the provided configuration."""
+        if not Picamera2:
+            raise RuntimeError("Picamera2 library not available")
 
-        # Try direct camera first via OpenCV
-        self.cap = cv2.VideoCapture(self.config.camera_id)
-        if self.cap.isOpened():
-            self._configure_camera()
-            return
-
-        # Fallback to RTSP
-        self.cap = cv2.VideoCapture(self.config.stream_url, cv2.CAP_FFMPEG)
-        if self.cap.isOpened():
-            self._configure_camera()
-            return
-
-        raise RuntimeError("Failed to initialize camera")
-
-    def _configure_camera(self):
-        if self.cap:
-            self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.config.resolution[0])
-            self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.config.resolution[1])
-            self.cap.set(cv2.CAP_PROP_FPS, self.config.fps)
-            self.cap.set(cv2.CAP_PROP_BUFFERSIZE, self.config.buffer_size)
+        try:
+            self.picam2 = Picamera2(camera_num=self.config.camera_id)
+            video_config = self.picam2.create_video_configuration(
+                main={"size": self.config.resolution},
+                controls={"FrameRate": self.config.fps},
+            )
+            self.picam2.configure(video_config)
+            self.picam2.start()
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize Picamera2: {e}")
 
     def read_frame(self) -> Tuple[bool, Optional[np.ndarray]]:
-        if self.camera_type == "picamera2" and self.picam2:
-            try:
-                frame = self.picam2.capture_array()
-                # Picamera2 returns RGB even when BGR is requested.
-                # Convert to BGR so OpenCV processing works correctly.
-                frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                return True, frame
-            except Exception:
-                return False, None
-
-        if not self.cap or not self.cap.isOpened():
+        if not self.picam2:
             return False, None
-        return self.cap.read()
+        try:
+            frame = self.picam2.capture_array()
+            # Picamera2 returns RGB; convert to BGR for OpenCV processing
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            return True, frame
+        except Exception:
+            return False, None
 
     def is_opened(self) -> bool:
-        if self.camera_type == "picamera2":
-            return self.picam2 is not None
-        return self.cap is not None and self.cap.isOpened()
+        return self.picam2 is not None
 
-    def release(self):
-        if self.camera_type == "picamera2" and self.picam2:
+    def release(self) -> None:
+        if self.picam2:
             try:
                 self.picam2.close()
             except Exception:
                 pass
             self.picam2 = None
-        if self.cap:
-            self.cap.release()


### PR DESCRIPTION
## Summary
- remove OpenCV fallback in `CameraManager` and always use Picamera2
- always return Picamera2 detection results
- default configs now force `camera_type='picamera2'`

## Testing
- `python3 -m py_compile services/camera_manager.py config/settings.py`
- `python3 -m unittest discover` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6861b13b9e5c8324b89da5c7db2523c9