### PR TITLE
Refactor auth service helper

### DIFF
--- a/web/handlers/auth_handlers.py
+++ b/web/handlers/auth_handlers.py
@@ -2,20 +2,12 @@
 Auth route handlers extracted from web/routes/auth_routes.py
 These are standalone functions that can be imported by admin_routes.py
 """
-from flask import request, jsonify, current_app, g
+from flask import request, jsonify, g
 from core.models import UserRole
-from services.auth_service import AuthService
-from database.repositories.user_repository import UserRepository
-from database.connection import DatabaseManager
+from web.utils.auth_utils import get_auth_service
 import logging
 
 logger = logging.getLogger(__name__)
-
-def get_auth_service() -> AuthService:
-    """Create auth service instance."""
-    db_manager = DatabaseManager(current_app.config['DATABASE_PATH'])
-    user_repository = UserRepository(db_manager)
-    return AuthService(user_repository)
 
 def list_users_handler():
     """List all users (admin only)."""

--- a/web/routes/auth_routes.py
+++ b/web/routes/auth_routes.py
@@ -1,21 +1,13 @@
 # web/routes/auth_routes.py
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify
 from core.models import UserRole
-from services.auth_service import AuthService
-from database.repositories.user_repository import UserRepository
-from database.connection import DatabaseManager
 from web.middleware.auth import require_auth, g
+from web.utils.auth_utils import get_auth_service
 import logging
 
 logger = logging.getLogger(__name__)
 
 auth_bp = Blueprint('auth', __name__)
-
-def get_auth_service() -> AuthService:
-    """Create auth service instance."""
-    db_manager = DatabaseManager(current_app.config['DATABASE_PATH'])
-    user_repository = UserRepository(db_manager)
-    return AuthService(user_repository)
 
 @auth_bp.route('/login', methods=['POST'])
 def login():

--- a/web/routes/setup_routes.py
+++ b/web/routes/setup_routes.py
@@ -2,23 +2,15 @@
 """
 Initial setup routes for first-time configuration
 """
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify
 from core.models import UserRole
-from services.auth_service import AuthService
-from database.repositories.user_repository import UserRepository
-from database.connection import DatabaseManager
 from web.middleware.ip_restriction import require_internal_network
+from web.utils.auth_utils import get_auth_service
 import logging
 
 logger = logging.getLogger(__name__)
 
 setup_bp = Blueprint('setup', __name__)
-
-def get_auth_service() -> AuthService:
-    """Create auth service instance."""
-    db_manager = DatabaseManager(current_app.config['DATABASE_PATH'])
-    user_repository = UserRepository(db_manager)
-    return AuthService(user_repository)
 
 @setup_bp.route('/status', methods=['GET'])
 def setup_status():

--- a/web/utils/__init__.py
+++ b/web/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for the web package."""
+
+from .auth_utils import get_auth_service  # noqa: F401
+

--- a/web/utils/auth_utils.py
+++ b/web/utils/auth_utils.py
@@ -1,0 +1,13 @@
+"""Helper utilities for authentication-related functionality."""
+
+from flask import current_app
+from services.auth_service import AuthService
+from database.repositories.user_repository import UserRepository
+from database.connection import DatabaseManager
+
+
+def get_auth_service() -> AuthService:
+    """Return an :class:`AuthService` instance using the current app's database."""
+    db_manager = DatabaseManager(current_app.config['DATABASE_PATH'])
+    user_repository = UserRepository(db_manager)
+    return AuthService(user_repository)


### PR DESCRIPTION
## Summary
- centralize auth service creation in `web/utils/auth_utils.py`
- replace duplicate helper implementations in routes/handlers

## Testing
- `pytest tests/test_auth_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68813b3cda448324acb509081e7d4450