### PR TITLE
Refactor internal access decorators

### DIFF
--- a/web/admin_routes.py
+++ b/web/admin_routes.py
@@ -3,10 +3,9 @@ Centralized admin API routes
 All admin-only endpoints are organized under /api/admin/*
 """
 from flask import Blueprint, request, jsonify, current_app
-from functools import wraps
 from core.models import User, UserRole
-from web.middleware.auth import require_auth, require_admin, g
-from web.middleware.ip_restriction import require_internal_network
+from web.middleware import require_auth
+from web.middleware.decorators import require_admin_internal
 from utils.capture_logger import logger
 import json
 import os
@@ -16,10 +15,6 @@ from web.handlers.auth_handlers import list_users_handler, create_user_handler, 
 from web.handlers.log_handlers import get_logs_handler, get_log_files_handler, get_capture_logs_handler, download_logs_handler, clear_logs_handler
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/api/admin')
-
-# Combined decorator for admin + internal network
-def require_admin_internal(f):
-    return require_internal_network(require_admin(f))
 
 # User Management Routes
 @admin_bp.route('/users', methods=['GET'])

--- a/web/middleware/__init__.py
+++ b/web/middleware/__init__.py
@@ -1,12 +1,13 @@
-# web/middleware/__init__.py
-"""
-Middleware for the BirdCam web application
-"""
+"""Middleware exports for BirdCam."""
+
 from .auth import require_auth, require_admin
 from .ip_restriction import require_internal_network
+from .decorators import require_admin_internal, require_auth_internal
 
 __all__ = [
-    'require_auth',
-    'require_admin', 
-    'require_internal_network'
+    "require_auth",
+    "require_admin",
+    "require_internal_network",
+    "require_admin_internal",
+    "require_auth_internal",
 ]

--- a/web/middleware/decorators.py
+++ b/web/middleware/decorators.py
@@ -1,0 +1,15 @@
+"""Utility decorators combining authentication and IP restriction."""
+from typing import Callable
+
+from .auth import require_auth, require_admin
+from .ip_restriction import require_internal_network
+
+
+def require_admin_internal(func: Callable) -> Callable:
+    """Require admin privileges from an internal network."""
+    return require_internal_network(require_admin(func))
+
+
+def require_auth_internal(func: Callable) -> Callable:
+    """Require authenticated user from an internal network."""
+    return require_internal_network(require_auth(func))

--- a/web/routes/log_routes.py
+++ b/web/routes/log_routes.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, jsonify, request
-from web.middleware.auth import require_admin
-from web.middleware.ip_restriction import require_internal_network
+from web.middleware.decorators import require_admin_internal
 from web.utils.log_utils import convert_time_format, parse_journalctl_output
 import subprocess
 import json
@@ -11,11 +10,6 @@ import os
 
 # Create blueprint
 log_routes = Blueprint("logs", __name__, url_prefix="/api/logs")
-
-
-# Combined decorator for admin + internal network
-def require_admin_internal(f):
-    return require_internal_network(require_admin(f))
 
 
 @log_routes.route("/pi-capture", methods=["GET"])

--- a/web/routes/pi_proxy_routes.py
+++ b/web/routes/pi_proxy_routes.py
@@ -5,8 +5,9 @@ These routes add authentication to Pi camera streams
 """
 import requests
 from flask import Response, jsonify, request, stream_with_context
-from web.middleware.auth import require_auth, require_auth_with_query
-from web.middleware.ip_restriction import require_internal_network
+from web.middleware import require_auth
+from web.middleware.auth import require_auth_with_query
+from web.middleware.decorators import require_auth_internal
 import os
 
 def create_pi_proxy_routes(app, config):
@@ -17,10 +18,6 @@ def create_pi_proxy_routes(app, config):
     pi_host = os.getenv('CAPTURE_SERVER', os.getenv('PI_SERVER', 'localhost'))
     pi_port = os.getenv('CAPTURE_PORT', '8090')
     PI_SERVER = f"http://{pi_host}:{pi_port}"
-    
-    # Combined decorator for auth + internal network
-    def require_auth_internal(f):
-        return require_internal_network(require_auth(f))
     
     @app.route('/api/pi/camera/<camera_id>/stream')
     @require_auth_with_query

--- a/web/routes/processing_routes.py
+++ b/web/routes/processing_routes.py
@@ -6,21 +6,14 @@ import threading
 from flask import request, jsonify, send_from_directory, send_file
 from services.system_metrics import SystemMetricsCollector
 from pathlib import Path
-from web.middleware.auth import require_auth, require_admin, require_auth_or_secret
-from web.middleware.ip_restriction import require_internal_network
+from web.middleware import require_auth
+from web.middleware.auth import require_auth_or_secret
+from web.middleware.decorators import require_admin_internal, require_auth_internal
 
 def create_processing_routes(app, processing_service, video_repo, detection_repo, config):
     
     # Initialize system metrics collector
     metrics_collector = SystemMetricsCollector(str(config.processing.storage_path))
-    
-    # Combined decorator for admin + internal network
-    def require_admin_internal(f):
-        return require_internal_network(require_admin(f))
-    
-    # Combined decorator for auth + internal network  
-    def require_auth_internal(f):
-        return require_internal_network(require_auth(f))
     
     # Track startup time for uptime calculation
     import time

--- a/web/routes/registration_routes.py
+++ b/web/routes/registration_routes.py
@@ -7,8 +7,9 @@ from services.email_service import EmailService
 from database.repositories.email_settings_repository import EmailSettingsRepository
 from database.repositories.email_template_repository import EmailTemplateRepository
 from database.connection import DatabaseConnection
-from web.middleware.auth import require_admin, require_auth, g
-from web.middleware.ip_restriction import require_internal_network
+from flask import g
+from web.middleware import require_auth
+from web.middleware.decorators import require_admin_internal
 from utils.capture_logger import logger
 from core.email_template_model import EmailTemplateType
 import json
@@ -20,10 +21,6 @@ def create_registration_routes(reg_service: RegistrationService, email_service: 
     db_conn = DatabaseConnection()
     email_settings_repo = EmailSettingsRepository(db_conn)
     template_repo = EmailTemplateRepository(db_conn)
-    
-    # Combined decorator for admin + internal network
-    def require_admin_internal(f):
-        return require_internal_network(require_admin(f))
     
     @reg_bp.route('/api/register', methods=['POST'])
     def register():


### PR DESCRIPTION
## Summary
- add `require_admin_internal` and `require_auth_internal` helper decorators
- expose them through `web.middleware`
- use the new decorators in all routes
- remove per-file copies

## Testing
- `python -m py_compile web/middleware/decorators.py web/middleware/__init__.py web/admin_routes.py web/routes/log_routes.py web/routes/processing_routes.py web/routes/registration_routes.py web/routes/pi_proxy_routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: flask and others)*

------
https://chatgpt.com/codex/tasks/task_e_68813d57d5b883248212f2a6bae10f80