### PR TITLE
Fix missing admin decorator import

### DIFF
--- a/web/routes/processing_routes.py
+++ b/web/routes/processing_routes.py
@@ -6,7 +6,7 @@ import threading
 from flask import request, jsonify, send_from_directory, send_file
 from services.system_metrics import SystemMetricsCollector
 from pathlib import Path
-from web.middleware import require_auth
+from web.middleware import require_auth, require_admin
 from web.middleware.auth import require_auth_or_secret
 from web.middleware.decorators import require_admin_internal, require_auth_internal
 


### PR DESCRIPTION
## Summary
- fix NameError by importing `require_admin` in processing routes

## Testing
- `pytest -q` *(fails: Module cv2 AttributeError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68814581f8a8832492bccb7d800b8896